### PR TITLE
GAR-23: Ability to create new Season

### DIFF
--- a/API/GardenMind.API.Tests/IntegrationTestBase.cs
+++ b/API/GardenMind.API.Tests/IntegrationTestBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.Testing;
+﻿using GardenMind.Persistence;
+using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace GardenMind.API.Tests
 {
@@ -15,6 +16,11 @@ namespace GardenMind.API.Tests
                 BaseAddress = new Uri("https://localhost"),
                 AllowAutoRedirect = true
             };
+
+            using var scope = _factory.Services.CreateScope();
+            using var ctx = scope.ServiceProvider.GetService<GardenDbContext>();
+            ctx.Database.EnsureDeleted();
+            ctx.Database.EnsureCreated();
         }
 
         public HttpClient Client => _factory.CreateClient(_options);

--- a/API/GardenMind.API.Tests/Tests/SeasonsIntegrationTests.cs
+++ b/API/GardenMind.API.Tests/Tests/SeasonsIntegrationTests.cs
@@ -1,6 +1,4 @@
 ﻿using GardenMind.Services.Seasons.Models;
-using GardenMind.Services.Species.Models;
-using GardenMind.Shared.Models;
 using NUnit.Framework;
 
 namespace GardenMind.API.Tests.Tests

--- a/API/GardenMind.API.Tests/Tests/SeasonsIntegrationTests.cs
+++ b/API/GardenMind.API.Tests/Tests/SeasonsIntegrationTests.cs
@@ -1,0 +1,23 @@
+﻿using GardenMind.Services.Seasons.Models;
+using GardenMind.Services.Species.Models;
+using GardenMind.Shared.Models;
+using NUnit.Framework;
+
+namespace GardenMind.API.Tests.Tests
+{
+    public class SeasonsIntegrationTests : IntegrationTestBase
+    {
+        [Test]
+        public async Task CreateNewSeason()
+        {
+            //given
+            var request = new CreateSeasonRequest(false);
+
+            // when
+            var response = await Client.PostAsJsonAsync($"api/seasons", request);
+
+            // then
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/API/GardenMind.API/Controllers/SeasonsController.cs
+++ b/API/GardenMind.API/Controllers/SeasonsController.cs
@@ -1,0 +1,31 @@
+﻿using GardenMind.Services.Seasons;
+using GardenMind.Services.Seasons.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GardenMind.API.Controllers
+{
+    [ApiController]
+    [Route("api/seasons")]
+    public class SeasonsController : ControllerBase
+    {
+        private readonly ILogger<SeasonsController> _logger;
+        private readonly SeasonCreator _seasonCreator;
+
+        public SeasonsController(
+            ILogger<SeasonsController> logger,
+            SeasonCreator seasonCreator)
+        {
+            _logger = logger;
+            _seasonCreator = seasonCreator;
+        }
+
+        [HttpPost]
+        public async Task<CreatedResult> CreateSeason([FromBody]CreateSeasonRequest request, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Attempting to create a new season");
+            var newSeasonId = await _seasonCreator.Create(request, cancellationToken);
+
+            return Created("api/seasons/", newSeasonId);
+        }
+    }
+}

--- a/API/GardenMind.API/Program.cs
+++ b/API/GardenMind.API/Program.cs
@@ -1,4 +1,5 @@
 using GardenMind.Persistence;
+using GardenMind.Services.Seasons;
 using GardenMind.Services.Species;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -35,6 +36,7 @@ builder.Services.AddDbContext<GardenDbContext>((services, ctx) =>
 
 builder.Services.AddScoped<QuerySpecies>();
 builder.Services.AddScoped<SpeciesCreator>();
+builder.Services.AddScoped<SeasonCreator>();
 
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi

--- a/Domain/GardenMind.Domain.Tests/Plants/Events/PlantedEventTests.cs
+++ b/Domain/GardenMind.Domain.Tests/Plants/Events/PlantedEventTests.cs
@@ -14,7 +14,7 @@ public class PlantedEventTests
     public void PlantedEvent_Can_Not_Be_Created_With_Default_CreatedAt()
     {
         // given
-        var plant = GardeningTestingUtils.NewPlant();
+        var plant = PlantsTestingUtils.NewPlant();
 
         // when
         Action createPlantEvent = () => PlantEvent.CreatePlantedEvent(DateTime.MinValue, plant, null);
@@ -28,7 +28,7 @@ public class PlantedEventTests
     public void PlantedEvent_Has_Valid_Details(string? photoUri)
     {
         // given
-        var plant = GardeningTestingUtils.NewPlant();
+        var plant = PlantsTestingUtils.NewPlant();
 
         // when
         var plantedEvent = PlantEvent.CreatePlantedEvent(DateTime.UtcNow, plant, photoUri);

--- a/Domain/GardenMind.Domain.Tests/Plants/PlantTests.cs
+++ b/Domain/GardenMind.Domain.Tests/Plants/PlantTests.cs
@@ -20,7 +20,7 @@ public class PlantTests
     {
         tag = Guid.NewGuid();
         species = SpeciesTestingUtils.NewSpecies();
-        season = GardeningTestingUtils.NewPlannedSeason();
+        season = SeasonsTestingUtils.NewPlannedSeason();
     }
 
     [Test]
@@ -50,7 +50,7 @@ public class PlantTests
     public void Plant_Can_Not_Be_Created_After_Season_Terminated()
     {
         // given
-        var alreadyTerminatedSeason = GardeningTestingUtils.NewTerminatedSeason();
+        var alreadyTerminatedSeason = SeasonsTestingUtils.NewTerminatedSeason();
 
         // when
         Action createPlant = () => Plant.Create(tag, alreadyTerminatedSeason, species, DateTime.UtcNow);

--- a/Domain/GardenMind.Domain/Seasons/Exceptions/SeasonPendingException.cs
+++ b/Domain/GardenMind.Domain/Seasons/Exceptions/SeasonPendingException.cs
@@ -1,0 +1,8 @@
+﻿namespace GardenMind.Domain.Seasons.Exceptions;
+
+public class SeasonPendingException : Exception
+{
+    public SeasonPendingException() : base("There is already a pending season")
+    {
+    }
+}

--- a/GardenMind.SharedTest/PlantsTestingUtils.cs
+++ b/GardenMind.SharedTest/PlantsTestingUtils.cs
@@ -1,0 +1,15 @@
+﻿using GardenMind.Domain.Plants;
+
+namespace GardenMind.SharedTest;
+
+public class PlantsTestingUtils
+{
+    public static Plant NewPlant()
+    {
+        var tag = Guid.NewGuid();
+        var species = SpeciesTestingUtils.NewSpecies();
+        var season = SeasonsTestingUtils.NewPlannedSeason();
+
+        return Plant.Create(tag, season, species, DateTime.UtcNow);
+    }
+}

--- a/GardenMind.SharedTest/SeasonsTestingUtils.cs
+++ b/GardenMind.SharedTest/SeasonsTestingUtils.cs
@@ -1,13 +1,9 @@
-﻿using Bogus;
-using GardenMind.Domain.Plants;
-using GardenMind.Domain.Seasons;
+﻿using GardenMind.Domain.Seasons;
 
 namespace GardenMind.SharedTest;
 
-public class GardeningTestingUtils
+public class SeasonsTestingUtils
 {
-    private static Faker faker = new Faker();
-
     public static Season NewPlannedSeason()
     {
         return NewSeason(SeasonStatus.Planned);
@@ -41,14 +37,5 @@ public class GardeningTestingUtils
                 }
         }
         return season;
-    }
-
-    public static Plant NewPlant()
-    {
-        var tag = Guid.NewGuid();
-        var species = SpeciesTestingUtils.NewSpecies();
-        var season = NewPlannedSeason();
-
-        return Plant.Create(tag, season, species, DateTime.UtcNow);
     }
 }

--- a/Services/GardenMind.Services.Tests/Seasons/SeasonsCreatorTests.cs
+++ b/Services/GardenMind.Services.Tests/Seasons/SeasonsCreatorTests.cs
@@ -1,0 +1,62 @@
+﻿using FluentAssertions;
+using GardenMind.Domain.Seasons;
+using GardenMind.Persistence;
+using GardenMind.Services.Seasons;
+using GardenMind.Services.Seasons.Models;
+using Moq;
+using Moq.EntityFrameworkCore;
+
+namespace GardenMind.Services.Tests.Seasons
+{
+    [TestFixture]
+    public class SeasonsCreatorTests
+    {
+        private Mock<GardenDbContext> _ctx;
+        private SeasonCreator _sut;
+
+        private List<Season> _seasons = [];
+
+        [SetUp]
+        public void Setup()
+        {
+            _seasons = [];
+            _ctx = new Mock<GardenDbContext>();
+            _ctx.Setup(x => x.Seasons).ReturnsDbSet(_seasons);
+            _ctx.Setup(x => x.Seasons.Add(It.IsAny<Season>())).Callback<Season>((entry) =>
+            {
+                _seasons.Add(entry);
+            });
+            _ctx.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).Returns(() =>
+            {
+                var insertedSeason = _ctx.Object.Seasons.First();
+                var field = typeof(Season).GetProperty(nameof(Season.Id));
+                field!.SetValue(insertedSeason, Random.Shared.Next(0, 100));
+
+                return Task.FromResult(1);
+            });
+
+            _sut = new SeasonCreator(_ctx.Object);
+        }
+
+        [TestCaseSource(nameof(SeasonStatusByRequirement))]
+        public async Task Creates_Seasons_Successfully((bool shouldBeStarted, SeasonStatus expectedStatus) expectedData)
+        {
+            // given
+            var request = new CreateSeasonRequest(expectedData.shouldBeStarted);
+
+            // when
+            var createdId = await _sut.Create(request);
+
+            // then
+            createdId.Should().BeGreaterThan(0);
+            var createdSeason = _ctx.Object.Seasons.First();
+            createdSeason.Status.Should().Be(expectedData.expectedStatus);
+        }
+
+        public static IEnumerable<(bool, SeasonStatus)> SeasonStatusByRequirement()
+        {
+            yield return (false, SeasonStatus.Planned);
+            yield return (true, SeasonStatus.Started);
+        }
+    }
+}

--- a/Services/GardenMind.Services/Seasons/Models/CreateSeasonRequest.cs
+++ b/Services/GardenMind.Services/Seasons/Models/CreateSeasonRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace GardenMind.Services.Seasons.Models;
+
+public record CreateSeasonRequest(bool StartImmediately);

--- a/Services/GardenMind.Services/Seasons/SeasonCreator.cs
+++ b/Services/GardenMind.Services/Seasons/SeasonCreator.cs
@@ -1,0 +1,37 @@
+﻿using GardenMind.Domain.Seasons;
+using GardenMind.Domain.Seasons.Exceptions;
+using GardenMind.Persistence;
+using GardenMind.Services.Seasons.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace GardenMind.Services.Seasons;
+
+public class SeasonCreator
+{
+    private readonly GardenDbContext _ctx;
+
+    public SeasonCreator(GardenDbContext ctx)
+    {
+        _ctx = ctx;
+    }
+
+    public async Task<int> Create(CreateSeasonRequest request, CancellationToken cancellationToken = default)
+    {
+        var anySeasonsPending = await _ctx.Seasons.AnyAsync(x => !x.TerminatedAt.HasValue);
+        if (anySeasonsPending)
+        {
+            throw new SeasonPendingException();
+        }
+
+        var newSeason = Season.Create();
+        if (request.StartImmediately)
+        {
+            newSeason.Start();
+        }
+
+        _ctx.Seasons.Add(newSeason);
+        await _ctx.SaveChangesAsync(cancellationToken);
+
+        return newSeason.Id;
+    }
+}


### PR DESCRIPTION
- **Added endpoint to create Seasons, along with service and integration test**
- **Added unit tests for `SeasonsCreator`**
- **Split `GardeningTestingUtils` to smaller helper classes**
- **Fixed failing integration tests**
